### PR TITLE
Proguard couldnt see ResultInfo

### DIFF
--- a/core/java/android/app/ResultInfo.java
+++ b/core/java/android/app/ResultInfo.java
@@ -24,9 +24,6 @@ import android.os.Bundle;
 
 import java.util.Map;
 
-/**
- * {@hide}
- */
 public class ResultInfo implements Parcelable {
     public final String mResultWho;
     public final int mRequestCode;


### PR DESCRIPTION
because it was declared invisible to droiddoc, which creates the api-stubs for it
